### PR TITLE
Add a new Dev environment and separate from Local

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -4,7 +4,7 @@ import sys
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
-    os.environ.setdefault('DJANGO_CONFIGURATION', 'Dev')
+    os.environ.setdefault('DJANGO_CONFIGURATION', 'Local')
 
     from configurations.management import execute_from_command_line
 

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -87,7 +87,7 @@ class Base(Configuration):
     ROOT_URLCONF = 'mysite.urls'
 
 
-class Dev(Base):
+class Local(Base):
     DEBUG = True
 
     MIDDLEWARE = [
@@ -111,13 +111,28 @@ class Dev(Base):
     STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 
-class Staging(Base):
+class Dev(Base):
     DEBUG = True
 
     DATABASES = {'default': dj_database_url.config(conn_max_age=500)}
 
     ALLOWED_HOSTS = [
         '.herokuapp.com',
+    ]
+
+    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
+    STATIC_URL = '/app/static/'
+    STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+
+class Staging(Base):
+    DEBUG = True
+
+    DATABASES = {'default': dj_database_url.config(conn_max_age=500)}
+
+    ALLOWED_HOSTS = [
+        'mignonnesaurus-staging.herokuapp.com',
     ]
 
     STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'

--- a/mysite/wsgi.py
+++ b/mysite/wsgi.py
@@ -12,6 +12,6 @@ import os
 from configurations.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mysite.settings")
-os.environ.setdefault('DJANGO_CONFIGURATION', 'Dev')
+os.environ.setdefault('DJANGO_CONFIGURATION', 'Local')
 
 application = get_wsgi_application()


### PR DESCRIPTION
Added a new Dev environment in Heroku from which review apps will inherit, hence the ALLOWED_HOSTS for Staging can now be only the specific domain for staging.
A local setup is now separate and is called Local.